### PR TITLE
Rails5 support

### DIFF
--- a/riot_js-rails.gemspec
+++ b/riot_js-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
 
-  spec.add_dependency 'rails', '>= 3.0', '<= 5.0'
+  spec.add_dependency 'rails', '>= 3.0', '< 6.0'
   spec.add_dependency 'execjs', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 1.8'

--- a/test/test_riot_js_rails.rb
+++ b/test/test_riot_js_rails.rb
@@ -11,6 +11,6 @@ class TestRiotJsRails < Minitest::Test
 
     tag_compiled = ::RiotJs::Rails::Compiler.compile(tag_source)
 
-    assert_equal "riot.tag('test-tag', '<h1>{test}</h1><style>test-tag h1 { background-color: #666666; }</style><script>this.test = opts.test</script>', function(opts) {\n});", tag_compiled
+    assert_equal "riot.tag2('test-tag', '<h1>{test}</h1><style>test-tag h1 {background-color: #666666;}</style><script>this.test = opts.test</script>', '', '', function(opts) {\n}, '{ }');", tag_compiled
   end
 end


### PR DESCRIPTION
Rails 5 support wasn't working for anything greater than `5.0.0`, e.g. `5.0.0.1`, so I wanted to fix the gemspec. Found that the tests weren't working due to new riot.tag2 formatting. Fixed the test, then fixed the gemspec.
