### PR TITLE
Silence deprecations for sprockets v3.7

### DIFF
--- a/lib/riot_js/rails/processors/sprockets_processor_v3.rb
+++ b/lib/riot_js/rails/processors/sprockets_processor_v3.rb
@@ -18,7 +18,8 @@ module RiotJs
 
       def self.register_self(config)
         config.assets.configure do |env|
-          env.register_engine '.tag', self, mime_type: 'application/javascript'
+          opts = { mime_type: 'application/javascript', silence_deprecation: true }
+          env.register_engine '.tag', self, opts
         end
       end
 


### PR DESCRIPTION
Fixes deprecation warning:

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from block in register_self at [...]/riot_js-rails-0.6.0/lib/riot_js/rails/processors/sprockets_processor_v3.rb:21)
```
