### PR TITLE
Add turbolinks 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Muut Riot integration with Rails
 
  1. Nodejs - for tags compiling.
  2. jQuery - for tags mounting (if you're going to use helpers provided by gem).
- 3. Rails 3 and 4 supported
+ 3. Rails 3, 4 and 5 supported
 
 
 ## Installation
@@ -20,7 +20,7 @@ gem 'riot_js-rails'
 Execute:
 
     $ bundle install
-    
+
 Add ```riot``` and ```riot_rails``` to your ```application.js```:
 ```
 //= require riot

--- a/vendor/assets/javascripts/riot_rails.js
+++ b/vendor/assets/javascripts/riot_rails.js
@@ -38,25 +38,35 @@
 
   var handleTurbolinksPageLoad = function () {
     var unmountEvent;
+    var mountEvent;
 
-    if (Turbolinks.EVENTS) {
-      unmountEvent = Turbolinks.EVENTS.BEFORE_UNLOAD;
-    } else {
-      unmountEvent = 'page:receive';
-      Turbolinks.pagesCached(0);
-
-      if (window.ReactRailsUJS.RAILS_ENV_DEVELOPMENT) {
-        console.warn('The Turbolinks cache has been disabled (Turbolinks >= 2.4.0 is recommended).');
+    if (typeof Turbolinks.EVENTS !== 'undefined') {
+      if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+        // Turbolinks.EVENTS is in classic version 2.4.0+
+        mountEvent = 'page:change';
+        unmountEvent = Turbolinks.EVENTS.BEFORE_UNLOAD;
+      } else if (typeof Turbolinks.controller !== "undefined") {
+        // Turbolinks.controller is in version 5+
+        mountEvent = "turbolinks:load";
+        unmountEvent = "turbolinks:before-cache";
+      } else {
+        mountEvent = 'page:change';
+        unmountEvent = 'page:receive';
+        Turbolinks.pagesCached(0);
+        if (window.ReactRailsUJS.RAILS_ENV_DEVELOPMENT) {
+          console.warn('The Turbolinks cache has been disabled (Turbolinks >= 2.4.0 is recommended).');
+        }
       }
     }
 
-    $(document).on('page:change', function(){
+    $(document).on(mountEvent, function(){
       riotRails.mountAll();
     });
 
     $(document).on(unmountEvent, function(){
       riotRails.unmountAll();
     });
+
   };
 
   if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {

--- a/vendor/assets/javascripts/riot_rails.js
+++ b/vendor/assets/javascripts/riot_rails.js
@@ -37,8 +37,8 @@
   };
 
   var handleTurbolinksPageLoad = function () {
-    var unmountEvent;
     var mountEvent;
+    var unmountEvent;
 
     if (typeof Turbolinks.EVENTS !== 'undefined') {
       // Turbolinks.EVENTS is in classic version 2.4.0+
@@ -46,8 +46,8 @@
       unmountEvent = Turbolinks.EVENTS.BEFORE_UNLOAD;
     } else if (typeof Turbolinks.controller !== "undefined") {
       // Turbolinks.controller is in version 5+
-      mountEvent = "turbolinks:load";
-      unmountEvent = "turbolinks:before-cache";
+      mountEvent = 'turbolinks:load';
+      unmountEvent = 'turbolinks:before-cache';
     } else {
       mountEvent = 'page:change';
       unmountEvent = 'page:receive';
@@ -64,7 +64,6 @@
     $(document).on(unmountEvent, function(){
       riotRails.unmountAll();
     });
-
   };
 
   if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {

--- a/vendor/assets/javascripts/riot_rails.js
+++ b/vendor/assets/javascripts/riot_rails.js
@@ -41,21 +41,19 @@
     var mountEvent;
 
     if (typeof Turbolinks.EVENTS !== 'undefined') {
-      if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
-        // Turbolinks.EVENTS is in classic version 2.4.0+
-        mountEvent = 'page:change';
-        unmountEvent = Turbolinks.EVENTS.BEFORE_UNLOAD;
-      } else if (typeof Turbolinks.controller !== "undefined") {
-        // Turbolinks.controller is in version 5+
-        mountEvent = "turbolinks:load";
-        unmountEvent = "turbolinks:before-cache";
-      } else {
-        mountEvent = 'page:change';
-        unmountEvent = 'page:receive';
-        Turbolinks.pagesCached(0);
-        if (window.ReactRailsUJS.RAILS_ENV_DEVELOPMENT) {
-          console.warn('The Turbolinks cache has been disabled (Turbolinks >= 2.4.0 is recommended).');
-        }
+      // Turbolinks.EVENTS is in classic version 2.4.0+
+      mountEvent = 'page:change';
+      unmountEvent = Turbolinks.EVENTS.BEFORE_UNLOAD;
+    } else if (typeof Turbolinks.controller !== "undefined") {
+      // Turbolinks.controller is in version 5+
+      mountEvent = "turbolinks:load";
+      unmountEvent = "turbolinks:before-cache";
+    } else {
+      mountEvent = 'page:change';
+      unmountEvent = 'page:receive';
+      Turbolinks.pagesCached(0);
+      if (window.ReactRailsUJS.RAILS_ENV_DEVELOPMENT) {
+        console.warn('The Turbolinks cache has been disabled (Turbolinks >= 2.4.0 is recommended).');
       }
     }
 


### PR DESCRIPTION
Hi,

Turbolinks 5+ doesn't have `Turbolinks.EVENTS` and therefore `riot_js-rails` treats it as Turbolinks <2.4.0. I used [a react-rails PR](https://github.com/reactjs/react-rails/pull/475/files) as a reference to add Turbolinks 5+ support.